### PR TITLE
No std fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,15 @@
 language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+jobs:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+env:
+  - FEATURES=""
+  - FEATURES="no_std"
+script:
+  - cargo build --verbose --features "$FEATURES"
+  - cargo test --verbose --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "http://gadomski.github.io/utm"
 keywords = ["utm", "gis", "no_std"]
 
 [dependencies]
-num = {version = "0.3.0", optional = true, default-features = false}
+num = {version = "0.3.0", optional = true, default-features = false, features = ["libm"]}
 
 [features]
 no_std = ["num"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "http://gadomski.github.io/utm"
 keywords = ["utm", "gis", "no_std"]
 
 [dependencies]
-num = {version = "0.3.0", optional = true}
+num = {version = "0.3.0", optional = true, default-features = false}
 
 [features]
 no_std = ["num"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ use std::f64::consts::PI;
 #[cfg(feature = "no_std")]
 extern crate num;
 
-
 pub struct Ellipsoid {
     a: f64,
     f: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,11 @@ use std::f64::consts::PI;
 #[cfg(feature = "no_std")]
 extern crate num;
 
+#[cfg(feature = "no_std")]
+#[allow(unused_imports)]
+// it's not clear why this generates an unused imports, b/c tests fail w/o it
+use num::traits::float::Float;
+
 pub struct Ellipsoid {
     a: f64,
     f: f64,


### PR DESCRIPTION
@zendurix after digging in further, the `no_std` feature wasn't working in **master**. This PR should fix things up. Could you take a look and make sure it fits your needs?

Note that I've added `no_std` to our Travis build so we should be able to catch any regressions in the future.